### PR TITLE
KNX DPT generic description  and more 4-byte float DPTs.

### DIFF
--- a/xknx/knx/dpt.py
+++ b/xknx/knx/dpt.py
@@ -3,7 +3,39 @@ from xknx.exceptions import ConversionError
 
 
 class DPTBase:
-    """Base class for KNX data types."""
+    """
+    Base class for KNX data types.
+    KNX communicates using Group-addresses, and every Group Object represents a data point of some type.
+    To have a standardized interpretation of the data there are a number of Data Point types (DPT).
+    The DPT's is written like: xx.yyy, for example 14.056 for a 4-octet float, with Power info in Watts.
+    The Major number (xx) describes the data type (format and encoding) - while the the minor (YYY) number
+    describes the measurement with value range and unit.
+
+    More DTP's are added as new needs come up, but this a list of some of the commonly used ones:
+    1.yyy  boolean, like switching, on/off, open/close, move up/down, step
+    2.yyy  2 x boolean, e.g. switching + priority control
+    3.yyy  boolean + 3-bit unsigned value, e.g. dimming up/down
+    4.yyy  character (8-bit)
+    5.yyy  8-bit unsigned value, like dim value (0..100%), blinds position (0..100%)
+    6.yyy  8-bit signed (2's complement), e.g. +/- %
+    7.yyy  2-byte unsigned value, i.e. pulse counter
+    8.yyy  2-byte signed (2's complement), e.g. +/- %
+    9.yyy  2-byte float, e.g. temperature
+    10.yyy time (3 bytes)
+    11.yyy date (3 bytes)
+    12.yyy 4-byte unsigned value, i.e. pulse counter
+    13.yyy 4-byte signed (2's complement), i.e. flow, energy
+    14.yyy 4-byte float, IEEE 754, i.e. Electrical measurements: current, power
+    15.yyy access control
+    16.yyy string -> 14 characters (14 x 8-bit)
+    17.yyy scene number
+    18.yyy scene control
+    19.yyy date / time
+    20.yyy 8-bit enumeration, e.g. HVAC mode ('auto', 'comfort', 'standby', 'economy', 'protection')
+    28.yyy UTF-8
+    29.yyy V64, 64-bit signed value
+
+    """
 
     # pylint: disable=too-few-public-methods
     @staticmethod

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -44,9 +44,7 @@ class DPT4ByteUnsigned(DPTBase):
     @classmethod
     def _test_boundaries(cls, value):
         """Test if value is within defined range for this object."""
-        return value >= cls.value_min and \
-            value <= cls.value_max
-
+        return cls.value_min <= value <= cls.value_max
 
 
 class DPT4ByteSigned(DPT4ByteUnsigned):
@@ -57,7 +55,7 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     """
 
     value_min = -2147483648
-    value_max =  2147483647
+    value_max = 2147483647
     unit = ""
     resolution = 1
 

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -70,14 +70,16 @@ class DPTFloat(DPTBase):
     @classmethod
     def _test_boundaries(cls, value):
         """Test if value is within defined range for this object."""
-        return value >= cls.value_min and \
-            value <= cls.value_max
+        return cls.value_min <= value <= cls.value_max
 
 
 class DPTIEEE754(DPTBase):
     """
-    Abstraction for KNX 4 Octet Floating Point Numbers (IEEE754).
-    No value range seems to be defined for these values.
+    Abstraction for KNX 4 Octet Floating Point Numbers, with a maximum usable range as specified in IEEE 754.
+    The largest positive finite float literal is 3.40282347e+38f.
+    The smallest positive finite non-zero literal of type float is 1.40239846e-45f.
+    The negative minimum finite float literal is -3.40282347e+38f.
+    No value range are defined for DPTs 14.000-079.
 
     DPT 14.xxx
     """
@@ -169,9 +171,57 @@ class DPTElectricPotential(DPTIEEE754):
     unit = "V"
 
 
+class DPTEnergy(DPTIEEE754):
+    """
+    DPT_Value_Energy 14.031
+    """
+    unit = 'J'
+
+
+class DPTFrequency(DPTIEEE754):
+    """
+    DPT_Value_Frequency 14.033
+    """
+    unit = 'Hz'
+
+
+class DPTHeatFlowRate(DPTIEEE754):
+    """
+    DPT_Value_Heat_Flow_Rate 14.036
+    """
+    unit = 'W'
+
+
+class DPTPhaseAngleRad(DPTIEEE754):
+    """
+    DPT_Value_Phase_Angle, Radiant 14.054
+    """
+    unit = 'rad'
+
+
+class DPTPhaseAngleDeg(DPTIEEE754):
+    """
+    DPT_Value_Phase_Angle, Degree 14.055
+    """
+    unit = '°'
+
+
 class DPTPower(DPTIEEE754):
     """
-    DPT_Value_Power 14.056 
+    DPT_Value_Power 14.056
     """
     unit = "W"
 
+
+class DPTPowerFactor(DPTIEEE754):
+    """
+    DPT_Value_Power 14.057
+    """
+    unit = ''
+
+
+class DPTSpeed(DPTIEEE754):
+    """
+    DPT_Value_Speed 14.065
+    """
+    unit = 'm/s'


### PR DESCRIPTION
Just some generic Data Point Types documentation that I think was missing before.
Also added a few additional 4-byte float metrics that I get from my meters.

I will add tests as well, but in case you work on it, we can just as well get in these on your fork ASAP.